### PR TITLE
feat: load dual engine endpoints from app config

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,4 @@
+# Development environment configuration for Obiwan
+APP_ENV=development
+CREPE_BASE_URL=http://localhost:5002
+SPICE_BASE_URL=http://localhost:5003

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,4 @@
+# Production environment configuration for Obiwan
+APP_ENV=production
+CREPE_BASE_URL=https://crepe.your-domain.com
+SPICE_BASE_URL=https://spice.your-domain.com

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,4 @@
+# Test environment configuration for Obiwan
+APP_ENV=test
+CREPE_BASE_URL=http://crepe.test.example.com
+SPICE_BASE_URL=http://spice.test.example.com

--- a/README.md
+++ b/README.md
@@ -52,7 +52,40 @@ flutter run
 flutter run --release
 ```
 
-### 3. 웹 실행 (테스트용)
+### 3. 환경 변수 구성(AppConfig)
+
+듀얼 엔진 서비스(DualEngineService)는 환경 변수로 CREPE/SPICE 서버 URL을 받아 초기화됩니다. 개발/테스트/프로덕션별 URL을 아래와 같이 설정하세요.
+
+1. 예시 환경 파일을 복사하여 환경별 값을 입력합니다.
+
+   ```bash
+   cp .env.development.example .env.development
+   cp .env.test.example .env.test
+   cp .env.production.example .env.production
+   ```
+
+2. 각 파일에 다음 필드를 채웁니다.
+
+   | 변수 | 설명 |
+   | --- | --- |
+   | `APP_ENV` | `development`, `test`, `production` 중 하나 |
+   | `CREPE_BASE_URL` | 해당 환경의 CREPE API 기본 URL |
+   | `SPICE_BASE_URL` | 해당 환경의 SPICE API 기본 URL |
+
+   필요 시 `CREPE_URL_DEV/TEST/PROD`, `SPICE_URL_DEV/TEST/PROD` 값으로 환경별 세부 URL을 덮어쓸 수 있습니다.
+
+3. 실행 시 `start_app.sh`가 `.env.<APP_ENV>` 파일을 자동으로 읽어 `--dart-define` 인자를 설정합니다. 수동으로 실행할 경우 다음 예시를 참고하세요.
+
+   ```bash
+   flutter run \
+     --dart-define=APP_ENV=development \
+     --dart-define=CREPE_BASE_URL=http://localhost:5002 \
+     --dart-define=SPICE_BASE_URL=http://localhost:5003
+   ```
+
+환경 변수가 누락되면 앱 시작 단계에서 명확한 예외와 경고 로그가 출력됩니다.
+
+### 4. 웹 실행 (테스트용)
 
 ```bash
 # 웹 서버 시작

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+
+/// Centralized application configuration loader.
+///
+/// Reads configuration from `--dart-define` values (compile-time environment)
+/// and applies sensible defaults for supported platforms.
+class AppConfig {
+  AppConfig._({
+    required this.environment,
+    required this.crepeBaseUrl,
+    required this.spiceBaseUrl,
+  });
+
+  /// Canonical environment name (development, test, production).
+  final String environment;
+
+  /// Base URL for the CREPE engine API.
+  final String? crepeBaseUrl;
+
+  /// Base URL for the SPICE engine API.
+  final String? spiceBaseUrl;
+
+  /// Loads configuration from environment variables and platform defaults.
+  factory AppConfig.load() {
+    final environment = _normalizeEnvironment(
+      _readEnv('APP_ENV') ?? 'development',
+    );
+
+    final suffix = _envSuffix(environment);
+
+    // Prefer environment specific overrides, then global fallbacks.
+    final crepeUrl = _readEnv('CREPE_URL_$suffix') ?? _readEnv('CREPE_BASE_URL');
+    final spiceUrl = _readEnv('SPICE_URL_$suffix') ?? _readEnv('SPICE_BASE_URL');
+
+    return AppConfig._(
+      environment: environment,
+      crepeBaseUrl: _normalizeUrl(crepeUrl),
+      spiceBaseUrl: _normalizeUrl(spiceUrl),
+    );
+  }
+
+  /// Returns the suffix (DEV / TEST / PROD) for the current environment.
+  String get environmentSuffix => _envSuffix(environment);
+
+  /// Returns a list of missing configuration keys required for dual engine.
+  List<String> get missingDualEngineKeys {
+    final keys = <String>[];
+    if (crepeBaseUrl == null || crepeBaseUrl!.isEmpty) {
+      keys.add('CREPE_URL_${environmentSuffix} or CREPE_BASE_URL');
+    }
+    if (spiceBaseUrl == null || spiceBaseUrl!.isEmpty) {
+      keys.add('SPICE_URL_${environmentSuffix} or SPICE_BASE_URL');
+    }
+    return keys;
+  }
+
+  /// Reads the compile-time environment variable (set via --dart-define).
+  static String? _readEnv(String key) {
+    switch (key) {
+      case 'APP_ENV':
+        const value = String.fromEnvironment('APP_ENV', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'CREPE_BASE_URL':
+        const value = String.fromEnvironment('CREPE_BASE_URL', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'SPICE_BASE_URL':
+        const value = String.fromEnvironment('SPICE_BASE_URL', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'CREPE_URL_DEV':
+        const value = String.fromEnvironment('CREPE_URL_DEV', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'SPICE_URL_DEV':
+        const value = String.fromEnvironment('SPICE_URL_DEV', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'CREPE_URL_TEST':
+        const value = String.fromEnvironment('CREPE_URL_TEST', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'SPICE_URL_TEST':
+        const value = String.fromEnvironment('SPICE_URL_TEST', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'CREPE_URL_PROD':
+        const value = String.fromEnvironment('CREPE_URL_PROD', defaultValue: '');
+        return value.isEmpty ? null : value;
+      case 'SPICE_URL_PROD':
+        const value = String.fromEnvironment('SPICE_URL_PROD', defaultValue: '');
+        return value.isEmpty ? null : value;
+      default:
+        if (kDebugMode) {
+          debugPrint('⚠️ [AppConfig] Attempted to read unsupported key: $key');
+        }
+        return null;
+    }
+  }
+
+  static String _normalizeEnvironment(String value) {
+    final normalized = value.trim().toLowerCase();
+    switch (normalized) {
+      case 'prod':
+      case 'production':
+        return 'production';
+      case 'test':
+      case 'testing':
+        return 'test';
+      default:
+        return 'development';
+    }
+  }
+
+  static String _envSuffix(String environment) {
+    switch (environment) {
+      case 'production':
+        return 'PROD';
+      case 'test':
+        return 'TEST';
+      default:
+        return 'DEV';
+    }
+  }
+
+  static String? _normalizeUrl(String? url) {
+    if (url == null) return null;
+    final trimmed = url.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed.endsWith('/') ? trimmed.substring(0, trimmed.length - 1) : trimmed;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'screens/wave_start_screen.dart';
 import 'screens/pitch_test_screen.dart';
 import 'screens/vocal_app_screen.dart';
 import 'design_system/screens/vj_home_screen.dart';  // New Voice Journey import
+import 'config/app_config.dart';
 import 'core/debug_logger.dart';
 import 'core/error_handler.dart';
 import 'core/resource_manager.dart';
@@ -26,14 +27,27 @@ final bool _SAFE_MODE = _kSafeModeStr.toLowerCase() == 'true';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
+
+  final appConfig = AppConfig.load();
+  final missingConfig = appConfig.missingDualEngineKeys;
+  if (missingConfig.isNotEmpty) {
+    final message =
+        'Missing dual engine configuration: ${missingConfig.join(', ')} '
+        'for ${appConfig.environment} environment. Configure the URLs via --dart-define.';
+    debugPrint('⚠️ [MAIN] $message');
+    throw StateError(message);
+  }
+
+  final dualEngineService = DualEngineService(config: appConfig);
+
   // 🚀 오비완 v3 디버깅 시스템 초기화
   print('🚀 오비완 v3 시작 - 디버깅 시스템 초기화 중...');
-  
+
   // 디버그 로거 초기화
   await logger.initialize();
   await logger.info('=== 오비완 v3 디버깅 시스템 시작 ===', tag: 'MAIN');
-  
+  await logger.info('환경 구성: ${appConfig.environment}', tag: 'MAIN');
+
   // 🔧 고도화된 디버그 도구 초기화 (디버그 모드에서만)
   if (_isDebugModeEnabled) {
     await _initializeAdvancedDebugTools();
@@ -60,7 +74,7 @@ void main() async {
     await logger.info('리소스 매니저 모니터링 시작', tag: 'MAIN');
     // 복구 시스템 초기화
     await ResilienceManager().initialize(
-      dualEngineService: DualEngineService(),
+      dualEngineService: dualEngineService,
       nativeAudioService: NativeAudioService.instance,
     );
     await logger.info('복구 시스템 초기화 완료', tag: 'MAIN');

--- a/lib/services/dual_engine_service.dart
+++ b/lib/services/dual_engine_service.dart
@@ -8,13 +8,17 @@ import 'package:flutter/foundation.dart';
 import '../models/analysis_result.dart';
 import 'single_pitch_tracker.dart';
 import 'ondevice_crepe_service.dart';
+import '../config/app_config.dart';
 import '../config/pipeline_preset.dart';
 
 /// 초고속 CREPE + SPICE 듀얼 엔진 서비스 (HTTP/2 + 배치 처리)
 class DualEngineService {
-  static const String _crepeUrl = 'http://localhost:5002';
-  static const String _spiceUrl = 'http://localhost:5003';
-  
+  static DualEngineService? _instance;
+
+  final AppConfig _config;
+  final String _crepeUrl;
+  final String _spiceUrl;
+
   late final Dio _crepeClient;
   late final Dio _spiceClient;
   
@@ -29,9 +33,22 @@ class DualEngineService {
   static const int _maxCacheSize = 10;
   
   // 싱글톤
-  static final DualEngineService _instance = DualEngineService._internal();
-  factory DualEngineService() => _instance;
-  
+  factory DualEngineService({AppConfig? config}) {
+    if (_instance != null) {
+      return _instance!;
+    }
+
+    if (config == null) {
+      throw StateError(
+        'DualEngineService must be initialized with an AppConfig before use. '
+        'Call DualEngineService(config: appConfig) during application startup.',
+      );
+    }
+
+    _instance = DualEngineService._internal(config);
+    return _instance!;
+  }
+
   // 배치 처리용 큐
   final List<BatchRequest> _crepeQueue = [];
   final List<BatchRequest> _spiceQueue = [];
@@ -40,9 +57,25 @@ class DualEngineService {
   // 연결 풀링
   final Map<String, String> _connectionPool = {};
 
-  DualEngineService._internal() {
+  DualEngineService._internal(AppConfig config)
+      : _config = config,
+        _crepeUrl = config.crepeBaseUrl ?? '',
+        _spiceUrl = config.spiceBaseUrl ?? '' {
+    _validateBaseUrls();
     _initializeClients();
     _startBatchProcessor();
+  }
+
+  void _validateBaseUrls() {
+    final missingKeys = _config.missingDualEngineKeys;
+    if (missingKeys.isNotEmpty) {
+      final message =
+          'DualEngineService base URL configuration is missing for '
+          '${_config.environment} environment. Please provide ${missingKeys.join(', ')} '
+          'using --dart-define or platform environment variables.';
+      debugPrint('⚠️ [DualEngineService] $message');
+      throw StateError(message);
+    }
   }
   
   void _initializeClients() {

--- a/start_app.sh
+++ b/start_app.sh
@@ -7,8 +7,57 @@ echo "================================"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+APP_ENVIRONMENT="${APP_ENV:-development}"
+ENV_FILE=".env.${APP_ENVIRONMENT}"
+
+if [ -f "$ENV_FILE" ]; then
+  echo "📦 환경 설정 로드: $ENV_FILE"
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+  APP_ENVIRONMENT="${APP_ENV:-$APP_ENVIRONMENT}"
+else
+  echo "⚠️ 환경 파일 $ENV_FILE 을(를) 찾을 수 없습니다. 기존 환경 변수를 사용합니다."
+fi
+
+ENV_SUFFIX="DEV"
+case "$APP_ENVIRONMENT" in
+  production)
+    ENV_SUFFIX="PROD"
+    ;;
+  test)
+    ENV_SUFFIX="TEST"
+    ;;
+esac
+
+FLUTTER_CMD=(flutter run -d macos "--dart-define=APP_ENV=$APP_ENVIRONMENT")
+
+if [ -n "$CREPE_BASE_URL" ]; then
+  FLUTTER_CMD+=("--dart-define=CREPE_BASE_URL=$CREPE_BASE_URL")
+fi
+
+if [ -n "$SPICE_BASE_URL" ]; then
+  FLUTTER_CMD+=("--dart-define=SPICE_BASE_URL=$SPICE_BASE_URL")
+fi
+
+CREPE_KEY="CREPE_URL_${ENV_SUFFIX}"
+SPICE_KEY="SPICE_URL_${ENV_SUFFIX}"
+CREPE_OVERRIDE="${!CREPE_KEY}"
+SPICE_OVERRIDE="${!SPICE_KEY}"
+
+if [ -n "$CREPE_OVERRIDE" ]; then
+  FLUTTER_CMD+=("--dart-define=${CREPE_KEY}=$CREPE_OVERRIDE")
+fi
+
+if [ -n "$SPICE_OVERRIDE" ]; then
+  FLUTTER_CMD+=("--dart-define=${SPICE_KEY}=$SPICE_OVERRIDE")
+fi
+
+echo "🚀 실행 환경: $APP_ENVIRONMENT"
+
 # Flutter 앱 실행
-flutter run -d macos
+"${FLUTTER_CMD[@]}"
 
 # 종료 시 메시지
 echo "================================"


### PR DESCRIPTION
## Summary
- add an AppConfig loader that centralizes environment-specific CREPE/SPICE endpoints
- inject the loaded AppConfig into DualEngineService at startup and fail fast when URLs are missing
- document and script environment setups with example .env files and start_app.sh updates

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2128a9040832bbad99cbfa6ed5e4a